### PR TITLE
fix a little syntax error, quotation mark added in few echo commands

### DIFF
--- a/linux-install.sh
+++ b/linux-install.sh
@@ -22,10 +22,10 @@ then
     else
     	echo Git is not installed
     	echo Install it using your package manager
-    	echo i.e. (buntu, debian-based) sudo apt-get install git
+    	echo i.e. "(buntu, debian-based) sudo apt-get install git"
     fi
 else
     echo GIMP is not installed
     echo Install it using your package manager
-    echo i.e. (buntu, debian-based) sudo apt-get install gimp
+    echo i.e. "(buntu, debian-based) sudo apt-get install gimp"
 fi


### PR DESCRIPTION
The linux-install script has failed in Ubuntu 16.04, the problem is a few echo commands without quote. So, adding this quotes the problem as gone.